### PR TITLE
correct imports in ContactNameExceptionImport

### DIFF
--- a/com.liferay.blade.upgrade.liferay70/src/com/liferay/blade/upgrade/liferay70/apichanges/ContactNameExceptionImport.java
+++ b/com.liferay.blade.upgrade.liferay70/src/com/liferay/blade/upgrade/liferay70/apichanges/ContactNameExceptionImport.java
@@ -45,9 +45,9 @@ public class ContactNameExceptionImport extends ImportStatementMigrator {
 	};
 
 	private final static String[] IMPORTS_FIXED = new String[] {
-		"com.liferay.portal.ContactFirstNameException",
-		"com.liferay.portal.ContactFullNameException",
-		"com.liferay.portal.ContactLastNameException"
+		"com.liferay.portal.kernel.exception.ContactNameException",
+		"com.liferay.portal.kernel.exception.ContactNameException",
+		"com.liferay.portal.kernel.exception.ContactNameException"
 	};
 
 	public ContactNameExceptionImport() {


### PR DESCRIPTION
as the exceptions are moved to inner classes , we should just import the public class .
![imports](https://cloud.githubusercontent.com/assets/12250744/16258292/c628af98-388f-11e6-8bb3-c648be11eb1d.png)
