### PR TITLE
include the Strings class to show help messages

### DIFF
--- a/com.liferay.blade.cli/bnd.bnd
+++ b/com.liferay.blade.cli/bnd.bnd
@@ -130,6 +130,7 @@ Private-Package:\
 	aQute.lib.io;-split-package:=merge-first,\
 	aQute.lib.json;-split-package:=merge-first,\
 	aQute.lib.justif;-split-package:=merge-first,\
+	aQute.lib.strings;-split-package:=merge-first,\
 	aQute.lib.utf8properties;-split-package:=merge-first,\
 	aQute.lib.zip;-split-package:=merge-first,\
 	aQute.libg.cryptography;-split-package:=merge-first,\


### PR DESCRIPTION
Hey Greg , the Peter the bnd guy added a Strings class  ,and this is related to showing help message .
So without the class we will get this error :

_$ blade server start -qqq
java.lang.reflect.InvocationTargetException
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
        at java.lang.reflect.Method.invoke(Unknown Source)
        at aQute.lib.getopt.CommandLine.execute(CommandLine.java:149)
        at aQute.lib.consoleapp.AbstractConsoleApp.run(AbstractConsoleApp.java:64)
        at com.liferay.blade.cli.blade.main(blade.java:59)
Caused by: java.lang.NoClassDefFoundError: aQute/lib/strings/Strings
        at aQute.libg.reporter.ReporterAdapter.exception(ReporterAdapter.java:136)
        at aQute.lib.consoleapp.AbstractConsoleApp.__main(AbstractConsoleApp.java:147)
        7 more_

after adding this class , we will get :

_$ blade server start -qqq


NAME

  start                       - Start server defined by your Liferay project



SYNOPSIS

   start [options] ...





OPTIONS



   [ -b, --background ]       - Start server in background

   [ -d, --debug ]            - Start server in debug mode

   [ -t, --tail ]             - Tail a running server_
