### PR TITLE
[Migrator] remove autoCorrectContext judgement condition

### DIFF
--- a/com.liferay.blade.api/bnd.bnd
+++ b/com.liferay.blade.api/bnd.bnd
@@ -1,4 +1,4 @@
-Bundle-Version: 1.0.0.${tstamp}
+Bundle-Version: 1.1.0.${tstamp}
 Bundle-SymbolicName: com.liferay.blade.api;singleton:=true
 
 Export-Package:  \

--- a/com.liferay.blade.api/src/com/liferay/blade/api/JavaFile.java
+++ b/com.liferay.blade.api/src/com/liferay/blade/api/JavaFile.java
@@ -29,6 +29,8 @@ public interface JavaFile extends SourceFile {
 
 	SearchResult findImport(String importName);
 
+	List<SearchResult> findImports(String importName, String[] imports);
+
 	List<SearchResult> findMethodDeclaration(String name, String[] params);
 
 	List<SearchResult> findMethodInvocations(String typeHint, String expressionValue, String methodName, String[] methodParamTypes);

--- a/com.liferay.blade.api/src/com/liferay/blade/api/SearchResult.java
+++ b/com.liferay.blade.api/src/com/liferay/blade/api/SearchResult.java
@@ -18,7 +18,7 @@ package com.liferay.blade.api;
 
 import java.io.File;
 
-public class SearchResult {
+public class SearchResult{
 
 	public final int endLine;
 	public final int endOffset;
@@ -37,6 +37,25 @@ public class SearchResult {
 		this.endOffset = endOffset;
 		this.startLine = startLine;
 		this.endLine = endLine;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj instanceof SearchResult) {
+			SearchResult sr = (SearchResult) obj;
+
+			if (startLine == sr.startLine && startOffset == sr.startOffset 
+					&& endOffset == sr.endOffset) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	@Override
+	public int hashCode() {
+		return file.hashCode();
 	}
 
 }

--- a/com.liferay.blade.api/src/com/liferay/blade/api/SearchResult.java
+++ b/com.liferay.blade.api/src/com/liferay/blade/api/SearchResult.java
@@ -51,8 +51,7 @@ public class SearchResult{
 		if (autoCorrectContext == null) {
 			if (other.autoCorrectContext != null)
 				return false;
-		} else if (!autoCorrectContext.equals(other.autoCorrectContext))
-			return false;
+		}
 		if (endLine != other.endLine)
 			return false;
 		if (endOffset != other.endOffset)

--- a/com.liferay.blade.api/src/com/liferay/blade/api/SearchResult.java
+++ b/com.liferay.blade.api/src/com/liferay/blade/api/SearchResult.java
@@ -41,21 +41,48 @@ public class SearchResult{
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof SearchResult) {
-			SearchResult sr = (SearchResult) obj;
-
-			if (startLine == sr.startLine && startOffset == sr.startOffset 
-					&& endOffset == sr.endOffset) {
-				return true;
-			}
-		}
-
-		return false;
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		SearchResult other = (SearchResult) obj;
+		if (autoCorrectContext == null) {
+			if (other.autoCorrectContext != null)
+				return false;
+		} else if (!autoCorrectContext.equals(other.autoCorrectContext))
+			return false;
+		if (endLine != other.endLine)
+			return false;
+		if (endOffset != other.endOffset)
+			return false;
+		if (file == null) {
+			if (other.file != null)
+				return false;
+		} else if (!file.equals(other.file))
+			return false;
+		if (fullMatch != other.fullMatch)
+			return false;
+		if (startLine != other.startLine)
+			return false;
+		if (startOffset != other.startOffset)
+			return false;
+		return true;
 	}
 
 	@Override
 	public int hashCode() {
-		return file.hashCode();
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((autoCorrectContext == null) ? 0 : autoCorrectContext.hashCode());
+		result = prime * result + endLine;
+		result = prime * result + endOffset;
+		result = prime * result + ((file == null) ? 0 : file.hashCode());
+		result = prime * result + (fullMatch ? 1231 : 1237);
+		result = prime * result + startLine;
+		result = prime * result + startOffset;
+		return result;
 	}
 
 }

--- a/com.liferay.blade.test/src/com/liferay/blade/test/InitJSPParseTest.java
+++ b/com.liferay.blade.test/src/com/liferay/blade/test/InitJSPParseTest.java
@@ -42,7 +42,7 @@ public class InitJSPParseTest {
 
 		List<Problem> problems = m.findProblems(new File("jsptests/jukebox-portlet/"), new NullProgressMonitor());
 
-		assertEquals(34, problems.size());
+		assertEquals(388, problems.size());
 
 		boolean found = false;
 

--- a/com.liferay.blade.test/src/com/liferay/blade/test/ProgressMonitorCancelTest.java
+++ b/com.liferay.blade.test/src/com/liferay/blade/test/ProgressMonitorCancelTest.java
@@ -61,7 +61,7 @@ public class ProgressMonitorCancelTest {
 
 		t.join();
 
-		final int expectedSize = 284;
+		final int expectedSize = 1324;
 		final int size = result.size();
 
 		assertTrue(size < expectedSize);

--- a/com.liferay.blade.upgrade.liferay70/projects/filetests/RenamePortalKernelImports.java
+++ b/com.liferay.blade.upgrade.liferay70/projects/filetests/RenamePortalKernelImports.java
@@ -1,0 +1,179 @@
+package com.test;
+
+import com.liferay.portal.model.Role;
+import com.liferay.portal.service.ResourcePermissionLocalServiceUtil;
+import com.liferay.portal.service.http.RoleLocalServiceUtil;
+
+public class Test extends MVCPortlet {
+	
+	String titleURL;
+	
+	public  void doView (RenderRequest renderRequest, RenderResponse renderResponse) throws PortletException, IOException 
+	{
+		
+		include("/view.jsp",renderRequest,renderResponse);
+		
+	}
+	
+	public void sendImage(ActionRequest request, ActionResponse response) {
+		
+		ThemeDisplay themeDisplay = (ThemeDisplay)request.getAttribute(WebKeys.THEME_DISPLAY);
+		SessionMessages.add(request, PortalUtil.getPortletId(request) + SessionMessages.KEY_SUFFIX_HIDE_DEFAULT_ERROR_MESSAGE);
+		long userId = themeDisplay.getUserId();
+		long groupId = themeDisplay.getScopeGroupId();
+	
+		UploadPortletRequest uploadRequest = PortalUtil.getUploadPortletRequest(request);
+		
+		long folderId = 0;
+		 
+	    java.io.File submissionFile = null;
+	    String submissionFileName = "";
+		try {
+			try {
+				ServiceContext serviceContext = ServiceContextFactory.getInstance(DLFileEntry.class.getName(), request);
+			} catch (SystemException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+		} catch (PortalException e3) {
+			e3.printStackTrace();
+		}
+	    
+		String contentType = "";
+	    String changeLog = "";
+	    Map<String, Fields> fieldsMap = new HashMap<String, Fields>();
+	    
+		if (uploadRequest != null) {
+		
+			submissionFileName = uploadRequest.getFileName("uploadFileForMessage");
+	    	submissionFile = uploadRequest.getFile("uploadFileForMessage");
+	    	contentType = uploadRequest.getContentType("uploadFileForMessage");
+	    	changeLog = ParamUtil.getString(request, "changeLog");
+
+		}
+	
+	 if(!submissionFileName.equals("")){
+		 
+		ServiceContext serviceContext = null;
+		try {
+			try {
+				serviceContext = ServiceContextFactory.getInstance(DLFileEntry.class.getName(), request);
+			} catch (SystemException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+		} catch (PortalException e3) {
+			e3.printStackTrace();
+		}
+	    
+		String title = submissionFileName;
+		String description = "Message Media";
+		DLFileEntry dlf = null;
+		long realUserId = themeDisplay.getRealUserId();
+		
+		FileInputStream fis = null;
+		
+		try {
+			fis = new FileInputStream(submissionFile);
+		} catch (FileNotFoundException e1) {
+			e1.printStackTrace();
+		}
+		
+	    try {
+	    	
+			dlf = DLFileEntryLocalServiceUtil.addFileEntry(realUserId, groupId, groupId, 0, submissionFileName, contentType, title, description, changeLog, 0, fieldsMap, submissionFile, fis, groupId, serviceContext);
+			long feID = dlf.getFileEntryId();
+			DLFileEntryLocalServiceUtil.updateFileEntry(realUserId, feID, submissionFileName, contentType, title, description, changeLog, false, 0, fieldsMap, submissionFile, fis, groupId, serviceContext);
+			
+			String primKeyDLFE = dlf.getPrimaryKey() + "";
+			String[] actionIds = new String[1];
+			
+			actionIds[0] = "VIEW";
+			
+			Role user = RoleLocalServiceUtil.getRole(dlf.getCompanyId(), RoleConstants.USER);
+			ResourcePermissionLocalServiceUtil.setResourcePermissions(dlf.getCompanyId(), "com.liferay.portlet.documentlibrary.model.DLFileEntry", 4, primKeyDLFE, user.getRoleId(), actionIds);
+			
+	    } catch (DuplicateFileException e) {
+			
+			int randomNumber = randInt(1000, 9999);
+			
+			title = title + "_" + randomNumber;
+			
+			try {
+				try {
+					dlf = DLFileEntryLocalServiceUtil.addFileEntry(realUserId, groupId, groupId, 0, submissionFileName, contentType, title, description, changeLog, 0, fieldsMap, submissionFile, fis, groupId, serviceContext);
+				} catch (SystemException e1) {
+					// TODO Auto-generated catch block
+					e1.printStackTrace();
+				}
+			} catch (PortalException e1) {
+				e1.printStackTrace();
+			}
+			
+			long feID = dlf.getFileEntryId();
+			
+			try {
+				try {
+					DLFileEntryLocalServiceUtil.updateFileEntry(realUserId, feID, submissionFileName, contentType, title, description, changeLog, false, 0, fieldsMap, submissionFile, fis, groupId, serviceContext);
+				} catch (SystemException e1) {
+					// TODO Auto-generated catch block
+					e1.printStackTrace();
+				}
+			} catch (PortalException e1) {
+				e1.printStackTrace();
+			}
+		
+			String[] actionIds = new String[1];
+			
+			actionIds[0] = "VIEW";	
+			String primKeyDLFE = dlf.getPrimaryKey() + "";
+			
+			Role user = null;
+			
+			try {
+				try {
+					user = RoleLocalServiceUtil.getRole(dlf.getCompanyId(), RoleConstants.USER);
+				} catch (SystemException e1) {
+					// TODO Auto-generated catch block
+					e1.printStackTrace();
+				}
+			} catch (PortalException e1) {
+				e1.printStackTrace();
+			}
+			
+			try {
+				try {
+					ResourcePermissionLocalServiceUtil.setResourcePermissions(dlf.getCompanyId(), "com.liferay.portlet.documentlibrary.model.DLFileEntry", 4, primKeyDLFE, user.getRoleId(), actionIds);
+				} catch (SystemException e1) {
+					// TODO Auto-generated catch block
+					e1.printStackTrace();
+				}
+			} catch (PortalException e1) {
+				e1.printStackTrace();
+			}
+			
+		} catch (PortalException e) {
+			e.printStackTrace();
+		} catch (SystemException e) {
+			e.printStackTrace();
+		}
+	    
+	    titleURL = "/documents/" + groupId + "/" + dlf.getFolderId() + "/" + dlf.getTitle();
+		
+	}
+		
+		System.out.println("OPEN IMAGE FROM THIS PATH: " + titleURL);
+		
+	}
+	
+	public static int randInt(int min, int max) {
+		
+	    Random rand = new Random();
+
+	    int randomNum = rand.nextInt((max - min) + 1) + min;
+
+	    return randomNum;
+	    
+	}
+
+}

--- a/com.liferay.blade.upgrade.liferay70/src/com/liferay/blade/upgrade/liferay70/ImportStatementMigrator.java
+++ b/com.liferay.blade.upgrade.liferay70/src/com/liferay/blade/upgrade/liferay70/ImportStatementMigrator.java
@@ -137,4 +137,12 @@ public abstract class ImportStatementMigrator extends AbstractFileMigrator<JavaF
 		return searchResults;
 	}
 
+	public static String getPrefix() {
+		return PREFIX;
+	}
+
+	public Map<String, String> get_imports() {
+		return _imports;
+	}
+
 }

--- a/com.liferay.blade.upgrade.liferay70/src/com/liferay/blade/upgrade/liferay70/apichanges/RenamePortalKernelImports.java
+++ b/com.liferay.blade.upgrade.liferay70/src/com/liferay/blade/upgrade/liferay70/apichanges/RenamePortalKernelImports.java
@@ -1,0 +1,239 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.liferay.blade.upgrade.liferay70.apichanges;
+
+import com.liferay.blade.api.AutoMigrator;
+import com.liferay.blade.api.FileMigrator;
+import com.liferay.blade.api.JavaFile;
+import com.liferay.blade.api.SearchResult;
+import com.liferay.blade.upgrade.liferay70.ImportStatementMigrator;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.osgi.service.component.annotations.Component;
+
+@Component(
+	property = {
+		"file.extensions=java",
+		"problem.summary=The portal-kernel and portal-impl folders have many packages with the same name. Therefore, all of these packages are affected by the split package problem",
+		"problem.tickets=LPS-61952",
+		"problem.title=Renamed Packages to Fix the Split Packages Problem",
+		"problem.section=#renamed-packages-to-fix-the-split-packages-problem",
+		"auto.correct=import"
+	},
+	service = {
+		FileMigrator.class,
+		AutoMigrator.class
+	}
+)
+public class RenamePortalKernelImports extends ImportStatementMigrator {
+
+	private final static String[] IMPORTS = new String[] {
+			"com.liferay.counter",
+			"com.liferay.mail.model",
+			"com.liferay.mail.service",
+			"com.liferay.mail.util",
+			"com.liferay.portal.exception",
+			"com.liferay.portal.jdbc.pool.metrics",
+			"com.liferay.portal.kernel.mail",
+			"com.liferay.portal.layoutconfiguration.util",
+			"com.liferay.portal.layoutconfiguration.util.xml",
+			"com.liferay.portal.mail",
+			"com.liferay.portal.model",
+			"com.liferay.portal.model.adapter",
+			"com.liferay.portal.model.impl",
+			"com.liferay.portal.portletfilerepository",
+			"com.liferay.portal.repository.proxy",
+			"com.liferay.portal.security.auth",
+			"com.liferay.portal.security.exportimport",
+			"com.liferay.portal.security.ldap",
+			"com.liferay.portal.security.membershippolicy",
+			"com.liferay.portal.security.permission",
+			"com.liferay.portal.security.permission.comparator",
+			"com.liferay.portal.security.pwd",
+			"com.liferay.portal.security.xml",
+			"com.liferay.portal.service.configuration",
+			"com.liferay.portal.service.http",
+			"com.liferay.portal.service.permission",
+			"com.liferay.portal.service.persistence.impl",
+			"com.liferay.portal.theme",
+			"com.liferay.portal.util",
+			"com.liferay.portal.util.comparator",
+			"com.liferay.portal.verify.model",
+			"com.liferay.portal.webserver",
+			"com.liferay.portlet",
+			"com.liferay.portlet.admin.util",
+			"com.liferay.portlet.announcements",
+			"com.liferay.portlet.asset",
+			"com.liferay.portlet.backgroundtask.util.comparator",
+			"com.liferay.portlet.blogs",
+			"com.liferay.portlet.blogs.exception",
+			"com.liferay.portlet.blogs.model",
+			"com.liferay.portlet.blogs.service",
+			"com.liferay.portlet.blogs.service.persistence",
+			"com.liferay.portlet.blogs.util.comparator",
+			"com.liferay.portlet.documentlibrary",
+			"com.liferay.portlet.dynamicdatamapping",
+			"com.liferay.portlet.expando",
+			"com.liferay.portlet.exportimport",
+			"com.liferay.portlet.imagegallerydisplay.display.context",
+			"com.liferay.portlet.journal.util",
+			"com.liferay.portlet.layoutsadmin.util",
+			"com.liferay.portlet.messageboards",
+			"com.liferay.portlet.messageboards.constants",
+			"com.liferay.portlet.messageboards.exception",
+			"com.liferay.portlet.messageboards.model",
+			"com.liferay.portlet.messageboards.service",
+			"com.liferay.portlet.messageboards.service.persistence",
+			"com.liferay.portlet.messageboards.util",
+			"com.liferay.portlet.messageboards.util.comparator",
+			"com.liferay.portlet.mobiledevicerules",
+			"com.liferay.portlet.portletconfiguration.util",
+			"com.liferay.portlet.rolesadmin.util",
+			"com.liferay.portlet.sites.util",
+			"com.liferay.portlet.social",
+			"com.liferay.portlet.trash",
+			"com.liferay.portlet.useradmin.util",
+			"com.liferay.portlet.ratings",
+			"com.liferay.portlet.ratings.definition",
+			"com.liferay.portlet.ratings.display.context",
+			"com.liferay.portlet.ratings.exception",
+			"com.liferay.portlet.ratings.model",
+			"com.liferay.portlet.ratings.service",
+			"com.liferay.portlet.ratings.service.persistence",
+			"com.liferay.portlet.ratings.transformer",
+			"com.liferay.portal.service"
+	};
+
+	private final static String[] IMPORTS_FIXED = new String[] {
+			"com.liferay.counter.kernel",
+			"com.liferay.mail.kernel.model",
+			"com.liferay.mail.kernel.service",
+			"com.liferay.mail.kernel.util",
+			"com.liferay.portal.kernel.exception",
+			"com.liferay.portal.kernel.jdbc.pool.metrics",
+			"com.liferay.mail.kernel.model",
+			"com.liferay.portal.kernel.layoutconfiguration.util",
+			"com.liferay.portal.kernel.layoutconfiguration.util.xml",
+			"com.liferay.portal.kernel.mail",
+			"com.liferay.portal.kernel.model",
+			"com.liferay.portal.kernel.model.adapter",
+			"com.liferay.portal.kernel.model.impl",
+			"com.liferay.portal.kernel.portletfilerepository",
+			"com.liferay.portal.kernel.repository.proxy",
+			"com.liferay.portal.kernel.security.auth",
+			"com.liferay.portal.kernel.security.exportimport",
+			"com.liferay.portal.kernel.security.ldap",
+			"com.liferay.portal.kernel.security.membershippolicy",
+			"com.liferay.portal.kernel.security.permission",
+			"com.liferay.portal.kernel.security.permission.comparator",
+			"com.liferay.portal.kernel.security.pwd",
+			"com.liferay.portal.kernel.security.xml",
+			"com.liferay.portal.kernel.service.configuration",
+			"com.liferay.portal.kernel.service.http",
+			"com.liferay.portal.kernel.service.permission",
+			"com.liferay.portal.kernel.service.persistence.impl",
+			"com.liferay.portal.kernel.theme",
+			"com.liferay.portal.kernel.util",
+			"com.liferay.portal.kernel.util.comparator",
+			"com.liferay.portal.kernel.verify.model",
+			"com.liferay.portal.kernel.webserver",
+			"com.liferay.kernel.portlet",
+			"com.liferay.admin.kernel.util",
+			"com.liferay.announcements.kernel",
+			"com.liferay.asset.kernel",
+			"com.liferay.background.task.kernel.util.comparator",
+			"com.liferay.blogs.kernel",
+			"com.liferay.blogs.kernel.exception",
+			"com.liferay.blogs.kernel.model",
+			"com.liferay.blogs.kernel.service",
+			"com.liferay.blogs.service.persistence",
+			"com.liferay.blogs.kernel.util.comparator",
+			"com.liferay.document.library.kernel",
+			"com.liferay.dynamic.data.mapping.kernel",
+			"com.liferay.expando.kernel",
+			"com.liferay.exportimport.kernel",
+			"com.liferay.image.gallery.display.kernel.display.context",
+			"com.liferay.journal.kernel.util",
+			"com.liferay.layouts.admin.kernel.util",
+			"com.liferay.message.boards.kernel",
+			"com.liferay.message.boards.kernel.constants",
+			"com.liferay.message.boards.kernel.exception",
+			"com.liferay.message.boards.kernel.model",
+			"com.liferay.message.boards.kernel.service",
+			"com.liferay.message.boards.kernel.service.persistence",
+			"com.liferay.message.boards.kernel.util",
+			"com.liferay.message.boards.kernel.util.comparator",
+			"com.liferay.mobile.device.rules",
+			"com.liferay.portlet.configuration.kernel.util",
+			"com.liferay.roles.admin.kernel.util",
+			"com.liferay.sites.kernel.util",
+			"com.liferay.social.kernel",
+			"com.liferay.trash.kernel",
+			"com.liferay.users.admin.kernel.util",
+			"com.liferay.ratings.kernel",
+			"com.liferay.ratings.kernel.definition",
+			"com.liferay.ratings.kernel.display.context",
+			"com.liferay.ratings.kernel.exception",
+			"com.liferay.ratings.kernel.model",
+			"com.liferay.ratings.kernel.service",
+			"com.liferay.ratings.kernel.service.persistence",
+			"com.liferay.ratings.kernel.transformer",
+			"com.liferay.portal.kernel.service"
+	};
+
+	public RenamePortalKernelImports() {
+		super(IMPORTS, IMPORTS_FIXED);
+	}
+
+	@Override
+	public List<SearchResult> searchFile(File file, JavaFile javaFile) {
+		final List<SearchResult> searchResults = new ArrayList<>();
+
+		for (String importName : get_imports().keySet()) {
+			final List<SearchResult> importResult = javaFile.findImports(importName, IMPORTS);
+
+			if (importResult.size() != 0) {
+				for (SearchResult result : importResult) {
+					result.autoCorrectContext = getPrefix() + importName;
+					searchResults.add(result);
+				}
+
+			}
+		}
+
+		return removeDuplicate(searchResults);
+	}
+
+	private List<SearchResult> removeDuplicate(List<SearchResult> searchResults) {
+		final Set<SearchResult> sr = new HashSet<>();
+		final List<SearchResult> newList = new ArrayList<>();
+
+		for (SearchResult searchResult : searchResults) {
+			if (sr.add(searchResult)) {
+				newList.add(searchResult);
+			}
+		}
+
+		return newList;
+	}
+
+}

--- a/com.liferay.blade.upgrade.liferay70/src/com/liferay/blade/upgrade/liferay70/apichanges/RenamePortalKernelImports.java
+++ b/com.liferay.blade.upgrade.liferay70/src/com/liferay/blade/upgrade/liferay70/apichanges/RenamePortalKernelImports.java
@@ -24,9 +24,7 @@ import com.liferay.blade.upgrade.liferay70.ImportStatementMigrator;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -224,11 +222,10 @@ public class RenamePortalKernelImports extends ImportStatementMigrator {
 	}
 
 	private List<SearchResult> removeDuplicate(List<SearchResult> searchResults) {
-		final Set<SearchResult> sr = new HashSet<>();
 		final List<SearchResult> newList = new ArrayList<>();
 
 		for (SearchResult searchResult : searchResults) {
-			if (sr.add(searchResult)) {
+			if (!newList.contains(searchResult)) {
 				newList.add(searchResult);
 			}
 		}

--- a/com.liferay.blade.upgrade.liferay70/test/com/liferay/blade/upgrade/liferay70/apichanges/RenamePortalKernelImportTest.java
+++ b/com.liferay.blade.upgrade.liferay70/test/com/liferay/blade/upgrade/liferay70/apichanges/RenamePortalKernelImportTest.java
@@ -1,0 +1,64 @@
+
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.liferay.blade.upgrade.liferay70.apichanges;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.liferay.blade.api.SearchResult;
+import com.liferay.blade.eclipse.provider.JavaFileJDT;
+
+@SuppressWarnings("restriction")
+public class RenamePortalKernelImportTest {
+	final File testFile = new File("projects/filetests/RenamePortalKernelImports.java");
+	RenamePortalKernelImports component;
+
+	@Before
+	public void beforeTest() {
+		assertTrue(testFile.exists());
+		component = new RenamePortalKernelImports();
+	}
+
+	@Test
+	public void renamePortalKernelImportTest() throws Exception {
+		List<SearchResult> results = component.searchFile(testFile,
+				new JavaFileJDT(testFile));
+
+		assertNotNull(results);
+		assertEquals(3, results.size());
+	}
+
+	@Test
+	public void renamePortalKernelImportTestTwice() throws Exception {
+		List<SearchResult> results = component.searchFile(testFile,
+				new JavaFileJDT(testFile));
+
+		results = component.searchFile(testFile,
+				new JavaFileJDT(testFile));
+
+		assertNotNull(results);
+		assertEquals(3, results.size());
+	}
+}


### PR DESCRIPTION
Unequal autoCorrectContext is not able to as a judgement condition for SearchResult equality.
eg: `import com.liferay.portal.service.http.RoleLocalServiceUtil;`
Target import name contains `com.liferay.portal.service` and `com.liferay.portal.service.http`
so this import sentence will be showed as two searchresult. Actually they are belong to same problem.