### PR TITLE
improve error message for blade server start command

### DIFF
--- a/com.liferay.blade.cli/src/com/liferay/blade/cli/ServerCommand.java
+++ b/com.liferay.blade.cli/src/com/liferay/blade/cli/ServerCommand.java
@@ -80,6 +80,13 @@ public class ServerCommand {
 			String cmd, File dir, String serverType, ServerOptions options)
 		throws Exception {
 
+		if (!dir.exists() || dir.listFiles() == null) {
+			_blade.error(serverType
+					+ " bundles folder does not exist in Liferay Workspace, execute 'gradlew initBundle' in order to create it.");
+
+			return;
+		}
+
 		for (File file : dir.listFiles()) {
 			String fileName = file.getName();
 


### PR DESCRIPTION
If the bundles folder do not exist or have no bundles in it, it will through ServerCommand NPE error.
This will make  the error more friendly to the users.