### PR TITLE
fix auto-correct blank problem for portlet.xml

### DIFF
--- a/com.liferay.blade.upgrade.liferay70/src/com/liferay/blade/upgrade/liferay70/apichanges/MVCPortletClassInPortletXML.java
+++ b/com.liferay.blade.upgrade.liferay70/src/com/liferay/blade/upgrade/liferay70/apichanges/MVCPortletClassInPortletXML.java
@@ -132,7 +132,8 @@ public class MVCPortletClassInPortletXML extends XMLFileMigrator implements Auto
 			}
 		}
 
-		if (corrected > 0) {
+        if( corrected > 0 && !xmlFile.getLocation().toFile().equals( file ) )
+        {
 			try {
 				IO.copy(xmlFile.getContents(), file);
 			} catch (IOException | CoreException e) {


### PR DESCRIPTION
@gamerson  I modified this for IDE-3063 show blank when correct automatically the problem "Moved MVCPortlet......"in find breaking change. The file and xmlFile coould be the same file in our IDE enviroment and it cause IO.copy() works in a wrong way. 