### PR TITLE
improve find deprecated methods for precision problem

### DIFF
--- a/com.liferay.blade.test/src/com/liferay/blade/test/AssetPreviewTagsTest.java
+++ b/com.liferay.blade.test/src/com/liferay/blade/test/AssetPreviewTagsTest.java
@@ -42,7 +42,7 @@ public class AssetPreviewTagsTest {
 
 		List<Problem> problems = m.findProblems(new File("jsptests/asset-preview/"), new NullProgressMonitor());
 
-		assertEquals(2, problems.size());
+		assertEquals(1, problems.size());
 
 		boolean found = false;
 

--- a/com.liferay.blade.test/src/com/liferay/blade/test/CustomAUIValidatorsTagsTest.java
+++ b/com.liferay.blade.test/src/com/liferay/blade/test/CustomAUIValidatorsTagsTest.java
@@ -42,7 +42,7 @@ public class CustomAUIValidatorsTagsTest {
 
 		List<Problem> problems = m.findProblems(new File("jsptests/custom-aui-validators/"), new NullProgressMonitor());
 
-		assertEquals(4, problems.size());
+		assertEquals(3, problems.size());
 
 		boolean found = false;
 

--- a/com.liferay.blade.test/src/com/liferay/blade/test/FileSetMigrationTest.java
+++ b/com.liferay.blade.test/src/com/liferay/blade/test/FileSetMigrationTest.java
@@ -49,7 +49,7 @@ public class FileSetMigrationTest {
 
 		List<Problem> problems = m.findProblems(fileset, new NullProgressMonitor());
 
-		assertEquals(4, problems.size());
+		assertEquals(3, problems.size());
 
 		boolean found = false;
 

--- a/com.liferay.blade.test/src/com/liferay/blade/test/InitJSPParseTest.java
+++ b/com.liferay.blade.test/src/com/liferay/blade/test/InitJSPParseTest.java
@@ -42,7 +42,7 @@ public class InitJSPParseTest {
 
 		List<Problem> problems = m.findProblems(new File("jsptests/jukebox-portlet/"), new NullProgressMonitor());
 
-		assertEquals(420, problems.size());
+		assertEquals(400, problems.size());
 
 		boolean found = false;
 

--- a/com.liferay.blade.test/src/com/liferay/blade/test/JournalArticleTagsTest.java
+++ b/com.liferay.blade.test/src/com/liferay/blade/test/JournalArticleTagsTest.java
@@ -42,9 +42,9 @@ public class JournalArticleTagsTest {
 
 		List<Problem> problems = m.findProblems(new File("jsptests/journal-article-tags/"), new NullProgressMonitor());
 
-		assertEquals(2, problems.size());
+		assertEquals(1, problems.size());
 
-		Problem problem = problems.get(1);
+		Problem problem = problems.get(0);
 
 		assertTrue(problem.file.getName().endsWith("JournalArticleTagsTest.jsp"));
 

--- a/com.liferay.blade.test/src/com/liferay/blade/test/deprecatedmethods/DeprecatedMethodsTest.java
+++ b/com.liferay.blade.test/src/com/liferay/blade/test/deprecatedmethods/DeprecatedMethodsTest.java
@@ -42,7 +42,7 @@ public class DeprecatedMethodsTest {
 			m.findProblems(new File("projects/deprecated-methods-test"), 
 				new NullProgressMonitor());
 
-		assertEquals(131, problems.size());
+		assertEquals(130, problems.size());
 	}
 
 	private final BundleContext context = FrameworkUtil.getBundle(this.getClass()).getBundleContext();

--- a/com.liferay.blade.upgrade.liferay70/src/com/liferay/blade/upgrade/liferay70/deprecatedmethods/deprecatedMethods62.json
+++ b/com.liferay.blade.upgrade.liferay70/src/com/liferay/blade/upgrade/liferay70/deprecatedmethods/deprecatedMethods62.json
@@ -803,26 +803,6 @@
 	},
 	{
 		"packageName": "com.liferay.portal.kernel.util",
-		"className": "Validator",
-		"deprecatedVersion": "6.2",
-		"methodName": "isNotNull",
-		"parameters": [
-			"Object[]"
-		],
-		"javadoc": "@deprecated As of 6.2.0, replaced by {ArrayUtil#isNotEmpty(Object[])}"
-	},
-	{
-		"packageName": "com.liferay.portal.kernel.util",
-		"className": "Validator",
-		"deprecatedVersion": "6.2",
-		"methodName": "isNull",
-		"parameters": [
-			"Object[]"
-		],
-		"javadoc": "@deprecated As of 6.2.0, replaced by {ArrayUtil#isEmpty(Object[])}"
-	},
-	{
-		"packageName": "com.liferay.portal.kernel.util",
 		"className": "FriendlyURLNormalizer",
 		"deprecatedVersion": "6.2",
 		"methodName": "normalize",
@@ -840,7 +820,7 @@
 		"parameters": [
 			"String",
 			"String",
-			"Class<?>..."
+			"Class<?>"
 		],
 		"javadoc": "@deprecated As of 6.2.0, replaced by {#MethodKey(Class,String,Class)}"
 	},

--- a/com.liferay.blade.upgrade.liferay70/src/com/liferay/blade/upgrade/liferay70/deprecatedmethods/deprecatedMethods70.json
+++ b/com.liferay.blade.upgrade.liferay70/src/com/liferay/blade/upgrade/liferay70/deprecatedmethods/deprecatedMethods70.json
@@ -155,7 +155,7 @@
 		"parameters": [
 			"String",
 			"String",
-			"Class<?"
+			"Class<?>"
 		],
 		"javadoc": "@deprecated As of 7.0.0"
 	},
@@ -167,7 +167,7 @@
 		"parameters": [
 			"String",
 			"String[]",
-			"Class<?"
+			"Class<?>"
 		],
 		"javadoc": "@deprecated As of 7.0.0"
 	},


### PR DESCRIPTION
Hey Greg,
I tested the find deprecated methods by using liferay-plugins repo 6.2 branch in IDE side.
And then find one problem:

We can't resolve some type in *.jsp file and also the variables defined in their super class since we pass the single jsp file or java file instead of the whole project.   When we can't resolve the type, our tool will think it possible matched and add the marker when the number of  parameters are the same.
 
The way we solve the possible matched problem is ok.  I just find the deprecated methods Validator.isNotNull(Object[]) and Validator.isNull(Object[]) are found too much times as possible matched problem. Actually, the real code people write in jsp is not deprecated and few people use  Validator.isNotNull(Object[]) and Validator.isNull(Object[]). (There are 66 Validator possible matched problems among 100 deprecated problems found in this repo).

 For the reason above,  I delete it in the json file to improve user experience. 
  