### PR TITLE
Simplify socket handling

### DIFF
--- a/cli/src/main/java/com/liferay/blade/cli/util/BladeUtil.java
+++ b/cli/src/main/java/com/liferay/blade/cli/util/BladeUtil.java
@@ -73,32 +73,27 @@ public class BladeUtil {
 	public static final String APP_SERVER_TYPE_PROPERTY = "app.server.type";
 
 	public static boolean canConnect(String host, int port) {
-		InetSocketAddress address = new InetSocketAddress(host, Integer.valueOf(port));
-		InetSocketAddress local = new InetSocketAddress(0);
+		InetSocketAddress localAddress = new InetSocketAddress(0);
+		InetSocketAddress remoteAddress = new InetSocketAddress(host, Integer.valueOf(port));
 
-		InputStream in = null;
+		return _canConnect(localAddress, remoteAddress);
+	}
 
+	private static boolean _canConnect(InetSocketAddress localAddress, InetSocketAddress remoteAddress) {
+		boolean canConnectBoolean = false;
+		
 		try (Socket socket = new Socket()) {
-			socket.bind(local);
-			socket.connect(address, 3000);
+			socket.bind(localAddress);
+			socket.connect(remoteAddress, 3000);
 
-			in = socket.getInputStream();
+			socket.getInputStream();
 
-			return true;
+			canConnectBoolean = true;
+		} 
+		catch (IOException e) {
+			
 		}
-		catch (Exception e) {
-		}
-		finally {
-			if (in != null) {
-				try {
-					in.close();
-				}
-				catch (Exception e) {
-				}
-			}
-		}
-
-		return false;
+		return canConnectBoolean;
 	}
 
 	public static void copy(InputStream in, File outputDir) throws Exception {

--- a/cli/src/main/java/com/liferay/blade/cli/util/BladeUtil.java
+++ b/cli/src/main/java/com/liferay/blade/cli/util/BladeUtil.java
@@ -79,23 +79,6 @@ public class BladeUtil {
 		return _canConnect(localAddress, remoteAddress);
 	}
 
-	private static boolean _canConnect(InetSocketAddress localAddress, InetSocketAddress remoteAddress) {
-		boolean canConnectBoolean = false;
-		
-		try (Socket socket = new Socket()) {
-			socket.bind(localAddress);
-			socket.connect(remoteAddress, 3000);
-
-			socket.getInputStream();
-
-			canConnectBoolean = true;
-		} 
-		catch (IOException e) {
-			
-		}
-		return canConnectBoolean;
-	}
-
 	public static void copy(InputStream in, File outputDir) throws Exception {
 		try (Jar jar = new Jar("dot", in)) {
 			Map<String, Resource> resources = jar.getResources();
@@ -578,6 +561,23 @@ public class BladeUtil {
 				}
 			}
 		}
+	}
+
+	private static boolean _canConnect(InetSocketAddress localAddress, InetSocketAddress remoteAddress) {
+		boolean canConnectBoolean = false;
+
+		try (Socket socket = new Socket()) {
+			socket.bind(localAddress);
+			socket.connect(remoteAddress, 3000);
+
+			socket.getInputStream();
+
+			canConnectBoolean = true;
+		}
+		catch (IOException ioe) {
+		}
+
+		return canConnectBoolean;
 	}
 
 	private static boolean _isSafelyRelative(File file, File destDir) {


### PR DESCRIPTION
This simplifies the BladeUtil.canConnect logic, there is no need to close the Socket's InputStream in a finally block as, per [Socket.close() javadoc](https://docs.oracle.com/javase/7/docs/api/java/net/Socket.html#close()), the Socket (wrapped in a try-with-resources) will close its associated InputStream when the Socket itself is closed.