### PR TITLE
BLADE-260 Handle Stream properly in in ServerStopCommand

### DIFF
--- a/cli/src/main/java/com/liferay/blade/cli/command/ServerStopCommand.java
+++ b/cli/src/main/java/com/liferay/blade/cli/command/ServerStopCommand.java
@@ -26,6 +26,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -144,7 +145,9 @@ public class ServerStopCommand extends BaseCommand<ServerStopArgs> {
 
 	private void _commandServer(Path dir, String serverType) throws Exception {
 		try (Stream<Path> list = Files.list(dir)) {
-			if (Files.notExists(dir) || !list.findAny().isPresent()) {
+			Collection<Path> paths = list.collect(Collectors.toList());
+
+			if (Files.notExists(dir) || paths.isEmpty()) {
 				_blade.error(
 					" bundles folder does not exist in Liferay Workspace, execute 'gradlew initBundle' in order to " +
 						"create it.");
@@ -152,7 +155,7 @@ public class ServerStopCommand extends BaseCommand<ServerStopArgs> {
 				return;
 			}
 
-			for (Path file : list.collect(Collectors.toList())) {
+			for (Path file : paths) {
 				Path fileName = file.getFileName();
 
 				if (fileName.startsWith(serverType) && Files.isDirectory(file)) {


### PR DESCRIPTION
Hi @gamerson , this addresses https://issues.liferay.com/browse/BLADE-260
This was because of usage of `findAny()` (a terminal stream operation), and then `collect(Collectors.toList())`, which could not be performed because `findAny` already closed the stream.