### PR TITLE
BLADE-335: blade update should install updates from nexus repository

### DIFF
--- a/cli/bnd.bnd
+++ b/cli/bnd.bnd
@@ -89,6 +89,13 @@ Private-Package:\
 	org.gradle.util,\
 	org.gradle.wrapper,\
 	\
+	org.jsoup,\
+	org.jsoup.helper,\
+	org.jsoup.internal,\
+	org.jsoup.nodes,\
+	org.jsoup.parser,\
+	org.jsoup.select,\
+	\
 	org.objectweb.asm.*,\
 	\
 	org.osgi.dto,\

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -94,6 +94,7 @@ dependencies {
 	compile group: "org.gradle", name: "gradle-base-services-groovy", version: "3.0"
 	compile group: "org.gradle", name: "gradle-core", version: "3.0"
 	compile group: "org.gradle", name: "gradle-tooling-api", version: "3.0"
+	compile group: "org.jsoup", name: "jsoup", version: "1.11.3"
 	compile name: "gradle-native-3.0"
 	compile name: "org.objectweb.asm-6.0.0"
 	compile name: "org.objectweb.asm.analysis-6.0.0"

--- a/cli/src/main/java/com/liferay/blade/cli/BladeCLI.java
+++ b/cli/src/main/java/com/liferay/blade/cli/BladeCLI.java
@@ -23,6 +23,7 @@ import com.beust.jcommander.ParameterException;
 
 import com.liferay.blade.cli.command.BaseArgs;
 import com.liferay.blade.cli.command.BaseCommand;
+import com.liferay.blade.cli.util.BladeUtil;
 import com.liferay.blade.cli.util.CombinedClassLoader;
 import com.liferay.blade.cli.util.WorkspaceUtil;
 
@@ -201,6 +202,14 @@ public class BladeCLI implements Runnable {
 			String output = simplifiedUsageString.toString();
 
 			out(output);
+
+			try {
+				updateAvailable();
+			}
+			catch (IOException ioe) {
+				ioe.printStackTrace();
+			}
+
 		}
 	}
 
@@ -331,6 +340,36 @@ public class BladeCLI implements Runnable {
 			_tracer.format("# " + s + "%n", args);
 			_tracer.flush();
 		}
+	}
+
+	public boolean updateAvailable() throws IOException {
+		boolean available = false;
+
+		String bladeVersion = BladeUtil.getBladeVersion(this);
+
+		out("The current version of blade is " + bladeVersion + System.lineSeparator());
+
+		boolean fromSnapshots = bladeVersion.contains("SNAPSHOT");
+
+		String updateVersion = "";
+
+		try {
+			updateVersion = BladeUtil.getUpdateVersion(fromSnapshots);
+
+			available = BladeUtil.shouldUpdate(bladeVersion, updateVersion);
+
+			if (available) {
+				out(
+					"Run \'blade update" + (fromSnapshots ? " --snapshots" : "") + "\' to start using " +
+						(fromSnapshots ? "the latest snapshot " : " ") + "version " + updateVersion +
+							System.lineSeparator());
+			}
+		}
+		catch (IOException ioe) {
+			available = false;
+		}
+
+		return available;
 	}
 
 	private static String _extractBasePath(String[] args) {

--- a/cli/src/main/java/com/liferay/blade/cli/command/UpdateArgs.java
+++ b/cli/src/main/java/com/liferay/blade/cli/command/UpdateArgs.java
@@ -16,6 +16,7 @@
 
 package com.liferay.blade.cli.command;
 
+import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 
 /**
@@ -23,4 +24,16 @@ import com.beust.jcommander.Parameters;
  */
 @Parameters(commandDescription = "Update blade to latest version", commandNames = "update")
 public class UpdateArgs extends BaseArgs {
+
+	public boolean isSnapshots() {
+		return _snapshots;
+	}
+
+	public void setSnapshots(boolean snapshots) {
+		_snapshots = snapshots;
+	}
+
+	@Parameter(description = "Switch to use the snapshot repository.", names = {"-s", "--snapshots"})
+	private boolean _snapshots;
+
 }

--- a/cli/src/main/java/com/liferay/blade/cli/command/UpdateCommand.java
+++ b/cli/src/main/java/com/liferay/blade/cli/command/UpdateCommand.java
@@ -20,6 +20,7 @@ import com.liferay.blade.cli.BladeCLI;
 import com.liferay.blade.cli.util.BladeUtil;
 
 import java.io.File;
+import java.io.IOException;
 
 /**
  * @author Gregory Amerson
@@ -33,19 +34,55 @@ public class UpdateCommand extends BaseCommand<UpdateArgs> {
 	public void execute() throws Exception {
 		BladeCLI bladeCLI = getBladeCLI();
 
+		UpdateArgs updateArgs = getArgs();
+
+		boolean snapshots = updateArgs.isSnapshots();
+
+		String oldUrl = "https://releases.liferay.com/tools/blade-cli/latest/blade.jar";
+
+		String url = "";
+
+		boolean available = false;
+
+		available = BladeUtil.updateAvailable(bladeCLI);
+
+		if (available) {
+
+			// Just because there is an update available does not mean that there is
+			// a url to a released blade.jar yet, or maybe the snapshot repo is empty.
+
+			try {
+				url = BladeUtil.getUpdateJarUrl(snapshots);
+			}
+			catch (IOException ioe) {
+				if (snapshots) {
+					bladeCLI.out("No jar is available from " + BladeUtil.SNAPSHOT_CONTEXT);
+				}
+				else {
+					bladeCLI.out("No jar is available from " + BladeUtil.RELEASE_CONTEXT);
+				}
+
+				url = oldUrl;
+			}
+		}
+		else {
+			url = oldUrl;
+		}
+
+		bladeCLI.out("Updating to " + url);
+
 		if (BladeUtil.isWindows()) {
 			bladeCLI.out(
 				"blade update cannot execute successfully because of Windows file locking. Please use following " +
 					"command:");
-			bladeCLI.out("\tjpm install -f https://releases.liferay.com/tools/blade-cli/latest/blade.jar");
+			bladeCLI.out("\tjpm install -f " + url);
 		}
 		else {
 			BaseArgs baseArgs = bladeCLI.getBladeArgs();
 
 			File baseDir = new File(baseArgs.getBase());
 
-			Process process = BladeUtil.startProcess(
-				"jpm install -f https://releases.liferay.com/tools/blade-cli/latest/blade.jar", baseDir);
+			Process process = BladeUtil.startProcess("jpm install -f " + url, baseDir);
 
 			int errCode = process.waitFor();
 

--- a/cli/src/main/java/com/liferay/blade/cli/util/BladeUtil.java
+++ b/cli/src/main/java/com/liferay/blade/cli/util/BladeUtil.java
@@ -32,12 +32,15 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.URL;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -49,10 +52,22 @@ import java.util.function.Predicate;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
+
+import org.gradle.internal.impldep.bsh.commands.dir;
+
+import org.jsoup.Connection;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+import org.osgi.framework.Constants;
 
 /**
  * @author Gregory Amerson
@@ -63,6 +78,16 @@ public class BladeUtil {
 	public static final String APP_SERVER_PARENT_DIR_PROPERTY = "app.server.parent.dir";
 
 	public static final String APP_SERVER_TYPE_PROPERTY = "app.server.type";
+
+	public static final String CDN_NEXUS_CONTEXT = "https://repository-cdn.liferay.com/nexus/content/repositories/";
+
+	public static final String GROUP_ID = "com.liferay.blade.cli";
+
+	public static final String RELEASE_CONTEXT =
+		CDN_NEXUS_CONTEXT + "liferay-public-releases/com/liferay/blade/" + GROUP_ID + "/";
+
+	public static final String SNAPSHOT_CONTEXT =
+		CDN_NEXUS_CONTEXT + "liferay-public-snapshots/com/liferay/blade/" + GROUP_ID + "/";
 
 	public static boolean canConnect(String host, int port) {
 		InetSocketAddress localAddress = new InetSocketAddress(0);
@@ -130,6 +155,34 @@ public class BladeUtil {
 		}
 
 		return properties;
+	}
+
+	public static String getBladeVersion(BladeCLI bladeCLI) throws IOException {
+		String version = "";
+
+		Class<? extends BladeCLI> clazz = bladeCLI.getClass();
+
+		ClassLoader cl = clazz.getClassLoader();
+
+		Enumeration<URL> e = cl.getResources("META-INF/MANIFEST.MF");
+
+		while (e.hasMoreElements()) {
+			URL u = e.nextElement();
+
+			Manifest m = new Manifest(u.openStream());
+
+			Attributes mainAttributes = m.getMainAttributes();
+
+			String bsn = mainAttributes.getValue(Constants.BUNDLE_SYMBOLICNAME);
+
+			if ((bsn != null) && bsn.equals("com.liferay.blade.cli")) {
+				Attributes attrs = mainAttributes;
+
+				version = attrs.getValue(Constants.BUNDLE_VERSION);
+			}
+		}
+
+		return version;
 	}
 
 	public static String getBundleVersion(Path pathToJar) throws IOException {
@@ -223,6 +276,172 @@ public class BladeUtil {
 		return ProjectTemplates.getTemplates(templatesFiles);
 	}
 
+	public static String getUpdateJarUrl(boolean snapshots) throws IOException {
+		String url = _nexusContext;
+
+		if (snapshots) {
+			url = SNAPSHOT_CONTEXT;
+		}
+
+		if (hasUpdateUrlFromBladeDir()) {
+			url = getUpdateUrlFromBladeDir();
+		}
+
+		String version = "";
+
+		String nextUrl = "";
+
+		String jarUrl = "";
+
+		Document versionsDocument;
+
+		Connection connection = Jsoup.connect(url);
+
+		versionsDocument = connection.get();
+
+		Elements tdOrPreElements = versionsDocument.select("td,pre");
+
+		for (Element potentialVersion : tdOrPreElements.select("a")) {
+			String bladeDir;
+
+			boolean prependUrl = false;
+
+			String href = potentialVersion.attr("href");
+
+			if (href.contains(url)) {
+				String hrefSubstring = href.substring(url .length());
+
+				bladeDir = hrefSubstring.replaceAll("/", "");
+			}
+			else {
+				bladeDir = href.replaceAll("/", "");
+
+				prependUrl = true;
+			}
+
+			if (bladeDir.matches("\\d+\\..*")) {
+				if (prependUrl) {
+					nextUrl = url + potentialVersion.attr("href");
+				}
+				else {
+					nextUrl = potentialVersion.attr("href");
+				}
+			}
+		}
+
+		if ("".equals(nextUrl)) {
+			throw new IOException("No directory found at url = " + url);
+		}
+
+		version = "nextUrl = " + nextUrl + "\n";
+
+		connection = Jsoup.connect(nextUrl);
+
+		Document jarsDocument = connection.get();
+
+		tdOrPreElements = jarsDocument.select("td,pre");
+
+		for (Element potentialJar : tdOrPreElements.select("a")) {
+			String bladeJar;
+
+			boolean prependUrl = false;
+
+			String href = potentialJar.attr("href");
+
+			if (href.contains(nextUrl)) {
+				String hrefSubstring = href.substring(nextUrl .length());
+
+				bladeJar = hrefSubstring.replaceAll("/", "");
+			}
+			else {
+				bladeJar = href.replaceAll("/", "");
+
+				prependUrl = true;
+			}
+
+			version = version + "\na jar = " + potentialJar.attr("href");
+
+			if (bladeJar.matches(".*\\.jar")) {
+				if (prependUrl) {
+					jarUrl = nextUrl + potentialJar.attr("href");
+				}
+				else {
+					jarUrl = potentialJar.attr("href");
+				}
+			}
+		}
+
+		if ("".equals(jarUrl)) {
+			throw new IOException("No jar found at nextUrl = " + nextUrl);
+		}
+
+		return jarUrl;
+	}
+
+	public static String getUpdateUrlFromBladeDir() {
+		String url = "no url";
+
+		final File updateUrlFile = new File(System.getProperty("user.home"), ".blade/update.url");
+
+		if (hasUpdateUrlFromBladeDir()) {
+			List<String> lines;
+
+			try {
+				lines = Files.readAllLines(Paths.get(updateUrlFile.getPath()), StandardCharsets.UTF_8);
+
+				url = lines.get(0);
+			}
+			catch (IOException ioe) {
+				ioe.printStackTrace();
+			}
+		}
+
+		return url;
+	}
+
+	public static String getUpdateVersion(boolean snapshots) throws IOException {
+		String url = _nexusContext;
+
+		if (snapshots) {
+			url = SNAPSHOT_CONTEXT;
+		}
+
+		if (hasUpdateUrlFromBladeDir()) {
+			url = getUpdateUrlFromBladeDir();
+		}
+
+		String version = "";
+
+		Document versionsDocument;
+
+		Connection connection = Jsoup.connect(url);
+
+		versionsDocument = connection.get();
+
+		Elements tdOrPreElements = versionsDocument.select("td,pre");
+
+		for (Element potentialVersion : tdOrPreElements.select("a")) {
+			String bladeDir;
+
+			String href = potentialVersion.attr("href");
+
+			if (href.contains(url)) {
+				String hrefSubstring = href.substring(url.length());
+
+				bladeDir = hrefSubstring.replaceAll("/", "");
+			}
+			else {
+				bladeDir = href.replaceAll("/", "");
+			}
+
+			if (bladeDir.matches("\\d+\\..*")) {
+				version = bladeDir;
+			}
+		}
+
+		return version;
+	}
+
 	public static boolean hasGradleWrapper(File dir) {
 		if (new File(dir, _GRADLEW_UNIX_FILE_NAME).exists() && new File(dir, _GRADLEW_WINDOWS_FILE_NAME).exists()) {
 			return true;
@@ -236,6 +455,20 @@ public class BladeUtil {
 		}
 
 		return false;
+	}
+
+	public static boolean hasUpdateUrlFromBladeDir() {
+		boolean has = false;
+
+		final File updateUrlFile = new File(System.getProperty("user.home"), ".blade/update.url");
+
+		if (updateUrlFile.exists() && !updateUrlFile.isDirectory()) {
+			if (updateUrlFile.length() > 0) {
+				has = true;
+			}
+		}
+
+		return has;
 	}
 
 	public static boolean isDirEmpty(final Path directory) throws IOException {
@@ -384,6 +617,56 @@ public class BladeUtil {
 		processBuilder.command(commands);
 	}
 
+	public static boolean shouldUpdate(String bladeVersion, String updateVersion) {
+		boolean should = false;
+
+		Matcher matcher = _pattern.matcher(bladeVersion);
+
+		matcher.find();
+
+		String bladeMajor = matcher.group(1);
+		String bladeMinor = matcher.group(2);
+		String bladePatch = matcher.group(3);
+
+		matcher = _pattern.matcher(updateVersion);
+
+		matcher.find();
+
+		String updateMajor = matcher.group(1);
+		String updateMinor = matcher.group(2);
+		String updatePatch = matcher.group(3);
+
+		if (Integer.parseInt(updateMajor) > Integer.parseInt(bladeMajor)) {
+			should = true;
+		}
+		else {
+			if (Integer.parseInt(updateMajor) < Integer.parseInt(bladeMajor)) {
+				should = false;
+			}
+			else {
+				if (Integer.parseInt(updateMinor) > Integer.parseInt(bladeMinor)) {
+					should = true;
+				}
+				else {
+					if (Integer.parseInt(updateMinor) < Integer.parseInt(bladeMinor)) {
+						should = false;
+					}
+					else {
+						if (Integer.parseInt(updatePatch) > Integer.parseInt(bladePatch)) {
+							should = true;
+						}
+					}
+				}
+			}
+		}
+
+		if (bladeVersion.contains("SNAPSHOT")) {
+			should = true;
+		}
+
+		return should;
+	}
+
 	public static Process startProcess(String command, File workingDir) throws Exception {
 		return startProcess(command, workingDir, null);
 	}
@@ -420,6 +703,31 @@ public class BladeUtil {
 
 	public static Process startProcess(String command, File dir, PrintStream out, PrintStream err) throws Exception {
 		return startProcess(command, dir, null, out, err);
+	}
+
+	public static boolean updateAvailable(BladeCLI bladeCLI) throws IOException {
+		boolean available = false;
+
+		String bladeVersion = getBladeVersion(bladeCLI);
+
+		boolean fromSnapshots = bladeVersion.contains("SNAPSHOT");
+
+		String updateVersion = getUpdateVersion(fromSnapshots);
+
+		boolean shouldUpdate = shouldUpdate(bladeVersion, updateVersion);
+
+		if (shouldUpdate) {
+			String updateJarUrl = getUpdateJarUrl(fromSnapshots);
+
+			if ("".equals(updateJarUrl)) {
+				bladeCLI.out("No update url available.");
+			}
+			else {
+				available = true;
+			}
+		}
+
+		return available;
 	}
 
 	private static ProcessBuilder _buildProcessBuilder(
@@ -497,5 +805,8 @@ public class BladeUtil {
 	private static final String _GRADLEW_UNIX_FILE_NAME = "gradlew";
 
 	private static final String _GRADLEW_WINDOWS_FILE_NAME = "gradlew.bat";
+
+	private static String _nexusContext = RELEASE_CONTEXT;
+	private static final Pattern _pattern = Pattern.compile("(\\d+)\\.(\\d+)\\.(\\d+)");
 
 }

--- a/cli/src/test/java/com/liferay/blade/cli/command/VersionCommandTest.java
+++ b/cli/src/test/java/com/liferay/blade/cli/command/VersionCommandTest.java
@@ -1,0 +1,251 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.liferay.blade.cli.command;
+
+import com.liferay.blade.cli.BladeTestResults;
+import com.liferay.blade.cli.TestUtil;
+import com.liferay.blade.cli.util.BladeUtil;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintWriter;
+
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * @author Vernon Singleton
+ */
+public class VersionCommandTest {
+
+	@Test
+	public void testBladeMajorLessThanUpdateMajor() {
+		boolean ok;
+
+		String bladeVersion = "1.5.9.1.2.3.4.5.6.7.8.9";
+		String updateVersion = "2.1.1.4.5.6-snapshot";
+
+		ok = BladeUtil.shouldUpdate(bladeVersion, updateVersion);
+
+		Assert.assertTrue(
+			"bladeVersion = " + bladeVersion + " should be updated to " + updateVersion + " but ok = " + ok, ok);
+	}
+
+	@Test
+	public void testBladeMajorMoreThanUpdateMajor() {
+		boolean ok;
+
+		String bladeVersion = "3.0.0.2018.10.23.1234";
+		String updateVersion = "2.5.9-SNAPSHOT";
+
+		ok = BladeUtil.shouldUpdate(bladeVersion, updateVersion);
+
+		Assert.assertFalse(
+			"bladeVersion = " + bladeVersion + " should NOT be updated to " + updateVersion + " but ok = " + ok, ok);
+	}
+
+	@Test
+	public void testBladeMinorLessThanUpdateMinor() {
+		boolean ok;
+
+		String bladeVersion = "12.1.9.SCHWIBBY";
+		String updateVersion = "12.2.1-snapshot";
+
+		ok = BladeUtil.shouldUpdate(bladeVersion, updateVersion);
+
+		Assert.assertTrue(
+			"bladeVersion = " + bladeVersion + " should be updated to " + updateVersion + " but ok = " + ok, ok);
+	}
+
+	@Test
+	public void testBladeMinorMoreThanUpdateMinor() {
+		boolean ok;
+
+		String bladeVersion = "3.6.0.001810231234";
+		String updateVersion = "3.5.9-SCHNAPS";
+
+		ok = BladeUtil.shouldUpdate(bladeVersion, updateVersion);
+
+		Assert.assertFalse(
+			"bladeVersion = " + bladeVersion + " should NOT be updated to " + updateVersion + " but ok = " + ok, ok);
+	}
+
+	@Test
+	public void testBladePatchLessThanUpdatePatch() {
+		boolean ok;
+
+		String bladeVersion = "123.10.10.SCHOOBY";
+		String updateVersion = "123.10.20-whiff";
+
+		ok = BladeUtil.shouldUpdate(bladeVersion, updateVersion);
+
+		Assert.assertTrue(
+			"bladeVersion = " + bladeVersion + " should be updated to " + updateVersion + " but ok = " + ok, ok);
+	}
+
+	@Test
+	public void testBladePatchMoreThanUpdatePatch() {
+		boolean ok;
+
+		String bladeVersion = "3.5.9.001810231234";
+		String updateVersion = "3.5.8.999999";
+
+		ok = BladeUtil.shouldUpdate(bladeVersion, updateVersion);
+
+		Assert.assertFalse(
+			"bladeVersion = " + bladeVersion + " should NOT be updated to " + updateVersion + " but ok = " + ok, ok);
+	}
+
+	@Test
+	public void testBladeVersionWithManifest() throws InterruptedException, IOException {
+		boolean ok;
+
+		Process ps = Runtime.getRuntime().exec(new String[] {"java", "-jar", "build/libs/blade.jar", "version"});
+
+		ps.waitFor();
+
+		InputStream is = ps.getInputStream();
+
+		byte[] b = new byte[is.available()];
+
+		is.read(b, 0, b.length);
+
+		String version = new String(b);
+
+		try (PrintWriter out = new PrintWriter("out0.txt")) {
+			out.println("testBladeVersionWithManifest: version = " + version);
+		}
+
+		if (version.length() > 1) {
+			ok = true;
+		}
+		else {
+			ok = false;
+		}
+
+		Assert.assertTrue("version = " + version + " ... this does not look right.", ok);
+	}
+
+	@Test
+	public void testBladeVersionWithNoManifest() throws Exception {
+		BladeTestResults bladeTestResults = TestUtil.runBlade(false, "version");
+
+		String errors = bladeTestResults.getErrors();
+
+		String expectedErrorMessage = "Could not locate version.";
+
+		Assert.assertTrue(
+			"Expected error message '" + expectedErrorMessage + "' was not returned",
+			errors.contains(expectedErrorMessage));
+	}
+
+	// This test should pass once blade is in the liferay-public-releases context of nexus
+
+	@Ignore
+	@Test
+	public void testGetUpdateJarUrl() throws IOException {
+		boolean ok;
+
+		// use liferay-public-releases context
+
+		String jarUrl = BladeUtil.getUpdateJarUrl(false);
+
+		try (PrintWriter out = new PrintWriter("out3.txt")) {
+			out.println("testGetUpdateJarUrl: jarUrl = " + jarUrl);
+		}
+
+		if (jarUrl.length() > 1) {
+			ok = true;
+		}
+		else {
+			ok = false;
+		}
+
+		Assert.assertTrue("jarUrl = " + jarUrl + " ... this does not look right.", ok);
+	}
+
+	@Test
+	public void testGetUpdateJarUrlFromSnapshots() throws IOException {
+		boolean ok;
+
+		// use liferay-public-snapshots context
+
+		String jarUrl = BladeUtil.getUpdateJarUrl(true);
+
+		try (PrintWriter out = new PrintWriter("out1.txt")) {
+			out.println("testGetUpdateSnapshotVersion: jarUrl = " + jarUrl);
+		}
+
+		if (jarUrl.length() > 1) {
+			ok = true;
+		}
+		else {
+			ok = false;
+		}
+
+		Assert.assertTrue("jarUrl = " + jarUrl + " ... this does not look right.", ok);
+	}
+
+	@Test
+	public void testGetUpdateJarUrlFromUrlInBladeDir() throws IOException {
+		boolean ok;
+
+		if (BladeUtil.hasUpdateUrlFromBladeDir()) {
+			String jarUrl = BladeUtil.getUpdateJarUrl(false);
+
+			try (PrintWriter out = new PrintWriter("out2.txt")) {
+				out.println("testGetUpdateUsingUrlFromBladeDirVersion: jarUrl = " + jarUrl);
+			}
+
+			if (jarUrl.length() > 1) {
+				ok = true;
+			}
+			else {
+				ok = false;
+			}
+
+			Assert.assertTrue("jarUrl = " + jarUrl + " ... this does not look right.", ok);
+		}
+	}
+
+	// This test should pass once blade is in the liferay-public-releases context of nexus
+
+	@Ignore
+	@Test
+	public void testGetUpdateVersion() throws IOException {
+		boolean ok;
+
+		// use liferay-public-releases context
+
+		String version = BladeUtil.getUpdateVersion(false);
+
+		try (PrintWriter out = new PrintWriter("out3.txt")) {
+			out.println("testGetUpdateVersion: version = " + version);
+		}
+
+		if (version.length() > 1) {
+			ok = true;
+		}
+		else {
+			ok = false;
+		}
+
+		Assert.assertTrue("version = " + version + " ... this does not look right.", ok);
+	}
+
+}


### PR DESCRIPTION
- testBladeVersionWithManifest
- testBladeVersionWithNoManifest
- testGetUpdateJarUrl
- testGetUpdateJarUrlFromSnapshots
- testGetUpdateJarUrlFromUrlInBladeDir
- testGetUpdateVersion

- added use of new nexus urls
- added snapshots option
- falls back to old url, if jars are not available in nexus