### PR TITLE
BLADE-347 Add getProperties() to CreateCommand

### DIFF
--- a/cli/src/main/java/com/liferay/blade/cli/command/CreateCommand.java
+++ b/cli/src/main/java/com/liferay/blade/cli/command/CreateCommand.java
@@ -251,6 +251,16 @@ public class CreateCommand extends BaseCommand<CreateArgs> {
 		}
 	}
 
+	protected Properties getProperties() {
+		BladeCLI bladeCLI = getBladeCLI();
+
+		BaseArgs baseArgs = bladeCLI.getBladeArgs();
+
+		File baseDir = new File(baseArgs.getBase());
+
+		return WorkspaceUtil.getGradleProperties(baseDir);
+	}
+
 	private static boolean _checkDir(File file) {
 		if (file.exists()) {
 			if (!file.isDirectory()) {
@@ -293,7 +303,7 @@ public class CreateCommand extends BaseCommand<CreateArgs> {
 			return baseDir;
 		}
 
-		Properties properties = WorkspaceUtil.getGradleProperties(baseDir);
+		Properties properties = getProperties();
 
 		String extDirProperty = (String)properties.get(WorkspaceConstants.DEFAULT_EXT_DIR_PROPERTY);
 
@@ -325,7 +335,7 @@ public class CreateCommand extends BaseCommand<CreateArgs> {
 			return baseDir;
 		}
 
-		Properties properties = WorkspaceUtil.getGradleProperties(baseDir);
+		Properties properties = getProperties();
 
 		String modulesDirValue = (String)properties.get(WorkspaceConstants.DEFAULT_MODULES_DIR_PROPERTY);
 
@@ -357,7 +367,7 @@ public class CreateCommand extends BaseCommand<CreateArgs> {
 			return baseDir;
 		}
 
-		Properties properties = WorkspaceUtil.getGradleProperties(baseDir);
+		Properties properties = getProperties();
 
 		String warsDirValue = (String)properties.get(WorkspaceConstants.DEFAULT_WARS_DIR_PROPERTY);
 


### PR DESCRIPTION
Hi @gamerson , this change must be merged first (and a new snapshot published) before we can merge https://github.com/gamerson/liferay-blade-cli/pull/597, as the changes in https://github.com/gamerson/liferay-blade-cli/pull/597 now have `maven-profile` using the blade snapshot, and it depends on this change to the `cli` project.