### PR TITLE
BLADE-347 Include maven-profile in default blade cli

### DIFF
--- a/cli/bnd.bnd
+++ b/cli/bnd.bnd
@@ -214,6 +214,7 @@ Private-Package:\
 -includeresource:\
 	@com.liferay.project.templates-*.jar,\
 	@jansi-*.jar,\
+	maven-profile.jar,\
 	tooling.zip,\
 	wrapper.zip,\
 	mvnw.cmd

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -20,7 +20,8 @@ apply plugin: "java"
 apply plugin: "maven-publish"
 
 task cliSourcesJar(type: Jar)
-task cliTestJar(type: Jar)
+task cliTestJar(type: Jar, dependsOn: testClasses)
+task createMavenProfileJar(type: Zip)
 task createToolingZip(type:Zip)
 task createWrapperZip(type:Zip)
 task downloadPortal(type: Download)
@@ -46,7 +47,7 @@ check {
 }
 
 clean.doFirst {
-	delete "${projectDir}/tooling.zip", "${projectDir}/wrapper.zip"
+	delete "${projectDir}/maven-profile.jar", "${projectDir}/tooling.zip", "${projectDir}/wrapper.zip"
 }
 
 cliSourcesJar {
@@ -57,6 +58,12 @@ cliSourcesJar {
 cliTestJar {
 	classifier = 'tests'
 	from sourceSets.test.output
+}
+
+createMavenProfileJar {
+	dependsOn ":extensions:maven-profile:jar"
+	archiveName = "maven-profile.jar"
+	destinationDir = new File("${projectDir}")
 }
 
 createToolingZip {
@@ -100,6 +107,7 @@ dependencies {
 	compile name: "org.objectweb.asm.commons-6.0.0"
 	compile name: "org.objectweb.asm.tree-6.0.0"
 	compile name: "org.objectweb.asm.util-6.0.0"
+	compile project(":extensions:maven-profile")
 	compile project(":gradle-tooling")
 
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
@@ -124,14 +132,14 @@ downloadPortal {
 }
 
 jar {
+
 	archiveName = 'blade.jar'
-	from createToolingZip, createWrapperZip
+	from createMavenProfileJar, createToolingZip, createWrapperZip
+
 }
 
-repositories {
-	maven {
-		url "https://repo.gradle.org/gradle/libs-releases"
-	}
+project(":extensions:maven-profile").afterEvaluate { project ->
+	createMavenProfileJar.from project.jar.archivePath
 }
 
 project(":gradle-tooling").afterEvaluate { tooling ->
@@ -153,7 +161,14 @@ publishing {
 			from components.java
 
 			artifact cliSourcesJar
+			artifact cliTestJar
 		}
+	}
+}
+
+repositories {
+	maven {
+		url "https://repo.gradle.org/gradle/libs-releases"
 	}
 }
 
@@ -161,6 +176,7 @@ sourceSets {
 	zips {
 		resources {
 			srcDir "${projectDir}"
+			include "maven-profile.jar"
 			include "tooling.zip"
 			include "wrapper.zip"
 		}
@@ -171,7 +187,7 @@ sourceSets {
 }
 
 test {
-	dependsOn createToolingZip, createWrapperZip, unzipPortal
+	dependsOn createMavenProfileJar, createToolingZip, createWrapperZip, unzipPortal
 
 	systemProperty 'buildDir', "${buildDir}"
 	systemProperty 'liferay.home', "${buildDir}/liferay-ce-portal-7.0-ga4"

--- a/cli/src/main/java/com/liferay/blade/cli/Extensions.java
+++ b/cli/src/main/java/com/liferay/blade/cli/Extensions.java
@@ -230,8 +230,12 @@ public class Extensions implements AutoCloseable {
 			_getServiceClassLoader().close();
 		}
 
-		if (_tempExtensionsDirectory != null) {
-			FileUtil.deleteDirIfExists(_tempExtensionsDirectory);
+		if ((_tempExtensionsDirectory != null) && Files.exists(_tempExtensionsDirectory)) {
+			try {
+				FileUtil.deleteDirIfExists(_tempExtensionsDirectory);
+			}
+			catch (IOException ioe) {
+			}
 		}
 	}
 
@@ -389,11 +393,11 @@ public class Extensions implements AutoCloseable {
 
 			FileUtil.copyDir(getPath(), _tempExtensionsDirectory);
 
-			InputStream inputStream = Extensions.class.getResourceAsStream("/maven-profile.jar");
+			try (InputStream inputStream = Extensions.class.getResourceAsStream("/maven-profile.jar")) {
+				Path mavenProfilePath = _tempExtensionsDirectory.resolve("maven-profile.jar");
 
-			Path mavenProfilePath = _tempExtensionsDirectory.resolve("maven-profile.jar");
-
-			Files.copy(inputStream, mavenProfilePath, StandardCopyOption.REPLACE_EXISTING);
+				Files.copy(inputStream, mavenProfilePath, StandardCopyOption.REPLACE_EXISTING);
+			}
 
 			URL[] jarUrls = _getJarUrls(_tempExtensionsDirectory);
 

--- a/extensions/maven-profile/build.gradle
+++ b/extensions/maven-profile/build.gradle
@@ -14,19 +14,20 @@ apply plugin: 'biz.aQute.bnd.builder'
 apply plugin: 'java'
 
 dependencies {
+	compile group: "com.liferay.blade", name: "com.liferay.blade.cli", version: "3.3+"
+
 	compileOnly group: "com.beust", name: "jcommander", version: "1.72"
-	compileOnly project(":cli")
 
 	testCompile gradleTestKit()
+	testCompile group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.5.0"
 	testCompile group: "junit", name: "junit", version: "4.12"
-	testCompile project(":cli")
-	testCompile project(path: ":cli", configuration: "testApi")
 }
 
 repositories {
 	maven {
-		url "https://liferay-test-01.ci.cloudbees.com/job/liferay-blade-cli/lastSuccessfulBuild/artifact/mavenRepo/"
+		url	"https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-snapshots/com/liferay/blade/com.liferay.blade.cli/"
 	}
+
 	maven {
 		url "https://repository-cdn.liferay.com/nexus/content/groups/public"
 	}

--- a/extensions/maven-profile/src/main/java/com/liferay/extensions/maven/profile/CreateCommandMaven.java
+++ b/extensions/maven-profile/src/main/java/com/liferay/extensions/maven/profile/CreateCommandMaven.java
@@ -17,9 +17,15 @@
 package com.liferay.extensions.maven.profile;
 
 import com.liferay.blade.cli.BladeCLI;
+import com.liferay.blade.cli.command.BaseArgs;
 import com.liferay.blade.cli.command.BladeProfile;
 import com.liferay.blade.cli.command.CreateArgs;
 import com.liferay.blade.cli.command.CreateCommand;
+import com.liferay.extensions.maven.profile.internal.MavenUtil;
+
+import java.io.File;
+
+import java.util.Properties;
 
 /**
  * @author Gregory Amerson
@@ -44,6 +50,16 @@ public class CreateCommandMaven extends CreateCommand {
 		createArgs.setBuild("maven");
 
 		super.execute();
+	}
+
+	protected Properties getProperties() {
+		BladeCLI bladeCLI = getBladeCLI();
+
+		BaseArgs baseArgs = bladeCLI.getBladeArgs();
+
+		File baseDir = new File(baseArgs.getBase());
+
+		return MavenUtil.getMavenProperties(baseDir);
 	}
 
 }

--- a/extensions/maven-profile/src/main/java/com/liferay/extensions/maven/profile/ServerInitCommandMaven.java
+++ b/extensions/maven-profile/src/main/java/com/liferay/extensions/maven/profile/ServerInitCommandMaven.java
@@ -18,6 +18,7 @@ package com.liferay.extensions.maven.profile;
 
 import com.liferay.blade.cli.BladeCLI;
 import com.liferay.blade.cli.command.BaseArgs;
+import com.liferay.blade.cli.command.BladeProfile;
 import com.liferay.blade.cli.command.ServerInitCommand;
 import com.liferay.blade.cli.util.WorkspaceUtil;
 import com.liferay.extensions.maven.profile.internal.MavenUtil;
@@ -27,6 +28,7 @@ import java.io.File;
 /**
  * @author Christopher Bryan Boyd
  */
+@BladeProfile("maven")
 public class ServerInitCommandMaven extends ServerInitCommand {
 
 	@Override

--- a/extensions/maven-profile/src/test/java/com/liferay/blade/cli/BladeTest.java
+++ b/extensions/maven-profile/src/test/java/com/liferay/blade/cli/BladeTest.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.liferay.blade.cli;
+
+import com.liferay.blade.cli.util.WorkspaceUtil;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * @author Gregory Amerson
+ */
+public class BladeTest extends BladeCLI {
+
+	public BladeTest() throws Exception {
+		super(StringPrintStream.newInstance(), StringPrintStream.newInstance(), System.in);
+
+		_userHomeDir = new File(System.getProperty("user.home"));
+	}
+
+	public BladeTest(boolean assertErrors) throws Exception {
+		this();
+
+		_assertErrors = assertErrors;
+	}
+
+	public BladeTest(File userHomeDir) throws Exception {
+		this();
+
+		_userHomeDir = userHomeDir;
+	}
+
+	public BladeTest(PrintStream ps) {
+		this(ps, ps, null);
+	}
+
+	public BladeTest(PrintStream ps, InputStream in) {
+		this(ps, ps, in);
+	}
+
+	public BladeTest(PrintStream outputStream, PrintStream errorStream) {
+		this(outputStream, errorStream, System.in);
+	}
+
+	public BladeTest(PrintStream outputStream, PrintStream errorStream, InputStream in) {
+		this(outputStream, errorStream, in, new File(System.getProperty("user.home")), true);
+	}
+
+	public BladeTest(PrintStream out, PrintStream err, InputStream in, File userHomeDir) {
+		this(out, err, in, userHomeDir, true);
+	}
+
+	public BladeTest(PrintStream out, PrintStream err, InputStream in, File userHomeDir, boolean assertErrors) {
+		super(out, err, in);
+
+		_userHomeDir = userHomeDir;
+		_assertErrors = assertErrors;
+	}
+
+	@Override
+	public BladeSettings getBladeSettings() throws IOException {
+		final File settingsFile;
+
+		if (WorkspaceUtil.isWorkspace(this)) {
+			File workspaceDir = WorkspaceUtil.getWorkspaceDir(this);
+
+			settingsFile = new File(workspaceDir, ".blade/settings.properties");
+		}
+		else {
+			settingsFile = new File(_userHomeDir, ".blade/settings.properties");
+		}
+
+		return new BladeSettings(settingsFile);
+	}
+
+	@Override
+	public Path getCachePath() {
+		Path userHomePath = _userHomeDir.toPath();
+
+		Path cachePath = userHomePath.resolve(".blade/cache");
+
+		try {
+			Files.createDirectories(cachePath);
+		}
+		catch (IOException ioe) {
+		}
+
+		return cachePath;
+	}
+
+	@Override
+	public Path getExtensionsPath() {
+		Path userHomePath = _userHomeDir.toPath();
+
+		Path extensionsPath = userHomePath.resolve(".blade/extensions");
+
+		try {
+			Files.createDirectories(extensionsPath);
+		}
+		catch (IOException ioe) {
+		}
+
+		return extensionsPath;
+	}
+
+	@Override
+	public void run(String[] args) throws Exception {
+		super.run(args);
+
+		if (_assertErrors) {
+			PrintStream err = err();
+
+			if (err instanceof StringPrintStream) {
+				StringPrintStream stringPrintStream = (StringPrintStream)err;
+
+				String errors = stringPrintStream.get();
+
+				if (!errors.isEmpty()) {
+					throw new Exception("Errors not empty:\n" + errors);
+				}
+			}
+		}
+	}
+
+	private boolean _assertErrors = true;
+	private File _userHomeDir;
+
+}

--- a/extensions/maven-profile/src/test/java/com/liferay/blade/cli/BladeTestResults.java
+++ b/extensions/maven-profile/src/test/java/com/liferay/blade/cli/BladeTestResults.java
@@ -14,30 +14,33 @@
  * limitations under the License.
  */
 
-package com.liferay.extensions.maven.profile;
-
-import com.liferay.blade.cli.command.BladeProfile;
-import com.liferay.blade.cli.command.InitArgs;
-import com.liferay.blade.cli.command.InitCommand;
+package com.liferay.blade.cli;
 
 /**
- * @author Gregory Amerson
- * @author Terry Jia
+ * @author Christopher Bryan Boyd
  */
-@BladeProfile("maven")
-public class InitCommandMaven extends InitCommand {
+public class BladeTestResults {
 
-	public InitCommandMaven() {
+	public BladeTestResults(BladeCLI bladeCLI, String output, String errors) {
+		_bladeCLI = bladeCLI;
+		_output = output;
+		_errors = errors;
 	}
 
-	@Override
-	@SuppressWarnings("deprecation")
-	public void execute() throws Exception {
-		InitArgs initArgs = getArgs();
-
-		initArgs.setProfileName("maven");
-
-		super.execute();
+	public BladeCLI getBladeCLI() {
+		return _bladeCLI;
 	}
+
+	public String getErrors() {
+		return _errors;
+	}
+
+	public String getOutput() {
+		return _output;
+	}
+
+	private final BladeCLI _bladeCLI;
+	private final String _errors;
+	private final String _output;
 
 }

--- a/extensions/maven-profile/src/test/java/com/liferay/blade/cli/TestUtil.java
+++ b/extensions/maven-profile/src/test/java/com/liferay/blade/cli/TestUtil.java
@@ -1,0 +1,171 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.liferay.blade.cli;
+
+import java.io.File;
+import java.io.InputStream;
+import java.io.PrintStream;
+
+import java.util.Scanner;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+
+import org.junit.Assert;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Text;
+
+/**
+ * @author Christopher Bryan Boyd
+ * @author Gregory Amerson
+ */
+public class TestUtil {
+
+	public static BladeTestResults runBlade(
+			BladeTest bladeTest, PrintStream outputStream, PrintStream errorStream, boolean assertErrors,
+			String... args)
+		throws Exception {
+
+		try {
+			bladeTest.run(args);
+		}
+		catch (Exception e) {
+		}
+
+		String error = errorStream.toString();
+
+		try (Scanner scanner = new Scanner(error)) {
+			while (scanner.hasNextLine()) {
+				String line = scanner.nextLine();
+
+				if ((line != null) && (line.length() > 0)) {
+					if (line.startsWith("SLF4J:")) {
+						continue;
+					}
+
+					if (line.contains("LC_ALL: cannot change locale")) {
+						continue;
+					}
+
+					if (assertErrors) {
+						Assert.fail("Encountered error at line: " + line + "\n" + error);
+					}
+				}
+			}
+		}
+
+		String content = outputStream.toString();
+
+		return new BladeTestResults(bladeTest, content, error);
+	}
+
+	public static BladeTestResults runBlade(
+			BladeTest bladeTest, PrintStream outputStream, PrintStream errorStream, String... args)
+		throws Exception {
+
+		return runBlade(bladeTest, outputStream, errorStream, true, args);
+	}
+
+	public static BladeTestResults runBlade(boolean assertErrors, String... args) throws Exception {
+		return runBlade(new File(System.getProperty("user.home")), System.in, assertErrors, args);
+	}
+
+	public static BladeTestResults runBlade(File userHomeDir, InputStream in, boolean assertErrors, String... args)
+		throws Exception {
+
+		StringPrintStream outputPrintStream = StringPrintStream.newInstance();
+
+		StringPrintStream errorPrintStream = StringPrintStream.newInstance();
+
+		BladeTest bladeTest = new BladeTest(outputPrintStream, errorPrintStream, in, userHomeDir, assertErrors);
+
+		return runBlade(bladeTest, outputPrintStream, errorPrintStream, assertErrors, args);
+	}
+
+	public static BladeTestResults runBlade(File userHomeDir, InputStream in, String... args) throws Exception {
+		return runBlade(userHomeDir, in, true, args);
+	}
+
+	public static BladeTestResults runBlade(File userHomeDir, String... args) throws Exception {
+		return runBlade(userHomeDir, System.in, true, args);
+	}
+
+	public static BladeTestResults runBlade(String... args) throws Exception {
+		return runBlade(new File(System.getProperty("user.home")), System.in, true, args);
+	}
+
+	public static void updateMavenRepositories(String projectPath) throws Exception {
+		File pomXmlFile = new File(projectPath + "/pom.xml");
+
+		DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+
+		DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
+
+		Document document = documentBuilder.parse(pomXmlFile);
+
+		_addNexusRepositoriesElement(document, "repositories", "repository");
+		_addNexusRepositoriesElement(document, "pluginRepositories", "pluginRepository");
+
+		TransformerFactory transformerFactory = TransformerFactory.newInstance();
+
+		Transformer transformer = transformerFactory.newTransformer();
+
+		DOMSource domSource = new DOMSource(document);
+
+		StreamResult streamResult = new StreamResult(pomXmlFile);
+
+		transformer.transform(domSource, streamResult);
+	}
+
+	private static void _addNexusRepositoriesElement(Document document, String parentElementName, String elementName) {
+		Element projectElement = document.getDocumentElement();
+
+		Element repositoriesElement = XMLTestUtil.getChildElement(projectElement, parentElementName);
+
+		if (repositoriesElement == null) {
+			repositoriesElement = document.createElement(parentElementName);
+
+			projectElement.appendChild(repositoriesElement);
+		}
+
+		Element repositoryElement = document.createElement(elementName);
+
+		Element idElement = document.createElement("id");
+
+		idElement.appendChild(document.createTextNode(System.currentTimeMillis() + ""));
+
+		Element urlElement = document.createElement("url");
+
+		Text urlText = document.createTextNode(_REPOSITORY_CDN_URL);
+
+		urlElement.appendChild(urlText);
+
+		repositoryElement.appendChild(idElement);
+		repositoryElement.appendChild(urlElement);
+
+		repositoriesElement.appendChild(repositoryElement);
+	}
+
+	private static final String _REPOSITORY_CDN_URL = "https://repository-cdn.liferay.com/nexus/content/groups/public";
+
+}

--- a/extensions/maven-profile/src/test/java/com/liferay/blade/cli/XMLTestUtil.java
+++ b/extensions/maven-profile/src/test/java/com/liferay/blade/cli/XMLTestUtil.java
@@ -1,0 +1,159 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.liferay.blade.cli;
+
+import java.io.StringWriter;
+
+import java.nio.file.Path;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+
+import org.junit.Assert;
+
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.w3c.dom.Text;
+
+/**
+ * @author Andrea Di Giorgi
+ */
+public class XMLTestUtil {
+
+	public static Element getChildElement(Element parentElement, String name) {
+		Node node = parentElement.getFirstChild();
+
+		do {
+			if (node.getNodeType() == Node.ELEMENT_NODE) {
+				Element element = (Element)node;
+
+				if (name.equals(element.getTagName())) {
+					return element;
+				}
+			}
+		}
+		while ((node = node.getNextSibling()) != null);
+
+		return null;
+	}
+
+	public static List<Element> getChildElements(Element element) {
+		NodeList nodeList = element.getChildNodes();
+
+		List<Element> elements = new ArrayList<>(nodeList.getLength());
+
+		for (int i = 0; i < nodeList.getLength(); i++) {
+			Node node = nodeList.item(i);
+
+			if (node.getNodeType() == Node.ELEMENT_NODE) {
+				Element childElement = (Element)node;
+
+				boolean ignoreNode = false;
+
+				NodeList childNodeList = childElement.getChildNodes();
+
+				for (int j = 0; j < childNodeList.getLength(); j++) {
+					Node childNode = childNodeList.item(j);
+
+					if (childNode.getNodeType() == Node.TEXT_NODE) {
+						Text text = (Text)childNode;
+
+						String textContent = text.getTextContent();
+
+						if (textContent.contains("Ignore Dependency Comparison")) {
+							ignoreNode = true;
+
+							break;
+						}
+					}
+				}
+
+				if (!ignoreNode) {
+					elements.add(childElement);
+				}
+			}
+		}
+
+		return elements;
+	}
+
+	public static void testXmlElement(
+			Path path, String parentElementString, List<Element> elements, int index, String expectedTagName,
+			String expectedTextContent)
+		throws TransformerException {
+
+		if (elements.size() <= index) {
+			StringBuilder sb = new StringBuilder();
+
+			sb.append("Missing child element <");
+			sb.append(expectedTagName);
+			sb.append('>');
+			sb.append(expectedTextContent);
+			sb.append("</");
+			sb.append(expectedTagName);
+			sb.append("> of ");
+			sb.append(parentElementString);
+			sb.append(" in ");
+			sb.append(path);
+
+			Assert.fail(sb.toString());
+		}
+
+		Element element = elements.get(index);
+
+		String elementString = toString(element);
+
+		Assert.assertEquals(
+			"Incorrect tag name of " + elementString + " in " + path, expectedTagName, element.getTagName());
+		Assert.assertEquals(
+			"Incorrect text content of " + elementString + " in " + path, expectedTextContent,
+			element.getTextContent());
+	}
+
+	public static String toString(Element element) throws TransformerException {
+		StringWriter stringWriter = new StringWriter();
+
+		_transformer.transform(new DOMSource(element), new StreamResult(stringWriter));
+
+		return stringWriter.toString();
+	}
+
+	private static final Transformer _transformer;
+
+	static {
+		TransformerFactory transformerFactory = TransformerFactory.newInstance();
+
+		try {
+			_transformer = transformerFactory.newTransformer();
+		}
+		catch (TransformerConfigurationException tce) {
+			throw new ExceptionInInitializerError(tce);
+		}
+
+		_transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+	}
+
+}

--- a/extensions/sample-command/build.gradle
+++ b/extensions/sample-command/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 
 repositories {
 	maven {
-		url "https://liferay-test-01.ci.cloudbees.com/job/liferay-blade-cli/lastSuccessfulBuild/artifact/mavenRepo/"
+		url "https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-snapshots/com/liferay/blade/com.liferay.blade.cli/"
 	}
 	maven {
 		url "https://repository-cdn.liferay.com/nexus/content/groups/public"

--- a/extensions/sample-profile/build.gradle
+++ b/extensions/sample-profile/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 
 repositories {
 	maven {
-		url "https://liferay-test-01.ci.cloudbees.com/job/liferay-blade-cli/lastSuccessfulBuild/artifact/mavenRepo/"
+		url "https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-snapshots/com/liferay/blade/com.liferay.blade.cli/"
 	}
 	maven {
 		url "https://repository-cdn.liferay.com/nexus/content/groups/public"


### PR DESCRIPTION
Hi @gamerson , this change includes the `maven-profile` classes in the default `cli` jar, and makes `maven-profile` use the snapshot repository for the blade dependency, rather than a project reference. 
Also included is the change to publish tests as a separate artifact.
For now, the test classes have also been copied into the `maven-profile` (using their original FQN's, so that they may be easily replaced when we publish the cli tests artifact)