### PR TITLE
BLADE-390 Parallel tests now require a -Pparallel flag

### DIFF
--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -249,7 +249,7 @@ test {
 
 	int forks = 1
 
-	if (!debug) {
+	if (!debug && project.hasProperty("parallel")) {
 		if (availableProcessors > 4) {
 
 			forks = availableProcessors - 2


### PR DESCRIPTION
Hi @gamerson , this addresses https://issues.liferay.com/projects/BLADE/issues/BLADE-390